### PR TITLE
Add partial Round support

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -86,7 +86,8 @@
   },
   "targetPlatforms": [
     "aplite",
-    "basalt"
+    "basalt",
+    "chalk"
   ],
   "sdkVersion": "3"
 }

--- a/src/ActionsMenu.c
+++ b/src/ActionsMenu.c
@@ -9,6 +9,11 @@
 #include "tertiary_text.h"
 #include "PebbleDialer.h"
 
+#define MENU_X_OFFSET (PBL_IF_RECT_ELSE(9, 27))
+#define MENU_Y_OFFSET (PBL_IF_RECT_ELSE(9 + STATUSBAR_Y_OFFSET, 27))
+#define MENU_WIDTH    (144 - 18)
+#define MENU_HEIGHT   (PBL_IF_RECT_ELSE(168 - 34, 126))
+
 static Layer* menuBackground;
 static MenuLayer* menu;
 static bool actionsMenuDisplayed = false;
@@ -20,9 +25,9 @@ static bool actionsMenuInited = false;
 static void menu_paint_background(Layer *layer, GContext *ctx)
 {
 	graphics_context_set_fill_color(ctx, GColorBlack);
-	graphics_fill_rect(ctx, GRect(0, 0, 144 - 18, 168 - 34), 0, GCornerNone);
+	graphics_fill_rect(ctx, GRect(0, 0, MENU_WIDTH, MENU_HEIGHT), 0, GCornerNone);
 	graphics_context_set_fill_color(ctx, GColorWhite);
-	graphics_fill_rect(ctx, GRect(1, 1, 144 - 20, 168 - 36), 0, GCornerNone);
+	graphics_fill_rect(ctx, GRect(1, 1, MENU_WIDTH - 2, MENU_HEIGHT - 2), 0, GCornerNone);
 }
 
 static uint16_t menu_get_num_sections_callback(MenuLayer *me, void *data) {
@@ -40,7 +45,7 @@ static int16_t menu_get_row_height_callback(MenuLayer *me,  MenuIndex *cell_inde
 
 static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuIndex *cell_index, void *data) {
 	graphics_context_set_text_color(ctx, GColorBlack);
-	graphics_draw_text(ctx, actions[cell_index->row], fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(5, 0, 144 - 20 - 10, 27), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+	graphics_draw_text(ctx, actions[cell_index->row], fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(5, 0, MENU_WIDTH - 12, 27), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
 }
 
 
@@ -165,11 +170,11 @@ void actions_menu_init(void)
 		return;
 	actionsMenuInited = true;
 
-	menuBackground = layer_create(GRect(9, 9 + STATUSBAR_Y_OFFSET, 144 - 18, 168 - 34));
+	menuBackground = layer_create(GRect(MENU_X_OFFSET, MENU_Y_OFFSET, MENU_WIDTH, MENU_HEIGHT));
 	layer_set_update_proc(menuBackground, menu_paint_background);
 	layer_set_hidden((Layer*) menuBackground, true);
 
-	menu = menu_layer_create(GRect(1, 1, 144 - 20, 168 - 36));
+	menu = menu_layer_create(GRect(1, 1, MENU_WIDTH - 2, MENU_HEIGHT - 2));
 
 	menu_layer_set_callbacks(menu, NULL, (MenuLayerCallbacks) {
 		.get_num_sections = menu_get_num_sections_callback,

--- a/src/CallLogWindow.c
+++ b/src/CallLogWindow.c
@@ -266,10 +266,10 @@ static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuI
 
 	graphics_context_set_text_color(ctx, GColorBlack);
 
-	graphics_draw_text(ctx, getName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(35, 0, 144 - 30, 20), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
-	graphics_draw_text(ctx, getDate(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_14), GRect(35, 20, 144 - 30, 15), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+	graphics_draw_text(ctx, getName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(35, 0, SCREEN_WIDTH - 30, 20), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+	graphics_draw_text(ctx, getDate(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_14), GRect(35, 20, SCREEN_WIDTH - 30, 15), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
 	if (hasNumberType)
-		graphics_draw_text(ctx, getNumber(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD), GRect(35, 35, 144 - 30, 20), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+		graphics_draw_text(ctx, getNumber(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD), GRect(35, 35, SCREEN_WIDTH - 30, 20), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
 
 	GBitmap* image;
 	switch (getType(cell_index->row))
@@ -347,7 +347,7 @@ static void window_appear(Window *me) {
 static void window_load(Window *me) {
 	Layer* topLayer = window_get_root_layer(window);
 
-	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, 144, 168 - 16));
+	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, SCREEN_WIDTH, HEIGHT_BELOW_STATUSBAR));
 
 	// Set all the callbacks for the menu layer
 	menu_layer_set_callbacks(menuLayer, NULL, (MenuLayerCallbacks){

--- a/src/CallWindow.c
+++ b/src/CallWindow.c
@@ -356,26 +356,28 @@ static void window_show(Window* me)
 
 static void window_load(Window* me)
 {
+	#define LEFT_MARGIN (PBL_IF_RECT_ELSE(5, 25))
+
 	Layer* topLayer = window_get_root_layer(window);
 
 	#ifdef  PBL_COLOR
-		callerBitmapLayer = bitmap_layer_create(GRect(0,STATUSBAR_Y_OFFSET, 144 - ACTION_BAR_WIDTH, 152));
+		callerBitmapLayer = bitmap_layer_create(GRect(PBL_IF_RECT_ELSE(0, 25),STATUSBAR_Y_OFFSET, SCREEN_WIDTH - ACTION_BAR_WIDTH - PBL_IF_RECT_ELSE(0, 25), HEIGHT_BELOW_STATUSBAR));
 		bitmap_layer_set_alignment(callerBitmapLayer, GAlignCenter);
 		layer_add_child(topLayer, bitmap_layer_get_layer(callerBitmapLayer));
 	#endif
 
-	title = stroked_text_layer_create(GRect(5, STATUSBAR_Y_OFFSET,144 - ACTION_BAR_WIDTH - 5,30));
+	title = stroked_text_layer_create(GRect(LEFT_MARGIN, STATUSBAR_Y_OFFSET, SCREEN_WIDTH - ACTION_BAR_WIDTH - LEFT_MARGIN,30));
 	stroked_text_layer_set_font(title, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
 	layer_add_child(topLayer, stroked_text_layer_get_layer(title));
 
-	callerName = stroked_text_layer_create(GRect(5, 30 + STATUSBAR_Y_OFFSET, 144 - ACTION_BAR_WIDTH - 5, 90));
+	callerName = stroked_text_layer_create(GRect(LEFT_MARGIN, 30 + STATUSBAR_Y_OFFSET,  SCREEN_WIDTH - ACTION_BAR_WIDTH - LEFT_MARGIN, 90));
 	stroked_text_layer_set_font(callerName, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
 	layer_add_child(topLayer, stroked_text_layer_get_layer(callerName));
 
-	callerNumType = stroked_text_layer_create(GRect(5,100 + STATUSBAR_Y_OFFSET,144 - ACTION_BAR_WIDTH - 5,20));
+	callerNumType = stroked_text_layer_create(GRect(LEFT_MARGIN,100 + STATUSBAR_Y_OFFSET, SCREEN_WIDTH - ACTION_BAR_WIDTH - LEFT_MARGIN,20));
 	layer_add_child(topLayer, stroked_text_layer_get_layer(callerNumType));
 
-	callerNumber = stroked_text_layer_create(GRect(5,122 + STATUSBAR_Y_OFFSET,144 - ACTION_BAR_WIDTH - 5,30));
+	callerNumber = stroked_text_layer_create(GRect(LEFT_MARGIN,122 + STATUSBAR_Y_OFFSET, SCREEN_WIDTH - ACTION_BAR_WIDTH - LEFT_MARGIN,30));
 	layer_add_child(topLayer, stroked_text_layer_get_layer(callerNumber));
 
 	buttonAnswer = gbitmap_create_with_resource(RESOURCE_ID_ANSWER);

--- a/src/ContactsWindow.c
+++ b/src/ContactsWindow.c
@@ -213,7 +213,7 @@ static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuI
 			return;
 
 	graphics_context_set_text_color(ctx, GColorBlack);
-	graphics_draw_text(ctx, getContactName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(3, 3, SCREEN_WIDTH - 3, 23), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+	graphics_draw_text(ctx, getContactName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(3, 3, SCREEN_WIDTH - 3, 23), GTextOverflowModeTrailingEllipsis, PBL_IF_RECT_ELSE(GTextAlignmentLeft, GTextAlignmentCenter), NULL);
 }
 
 static void filter(int button)

--- a/src/ContactsWindow.c
+++ b/src/ContactsWindow.c
@@ -213,7 +213,7 @@ static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuI
 			return;
 
 	graphics_context_set_text_color(ctx, GColorBlack);
-	graphics_draw_text(ctx, getContactName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(3, 3, 141, 23), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
+	graphics_draw_text(ctx, getContactName(cell_index->row), fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD), GRect(3, 3, SCREEN_WIDTH - 3, 23), GTextOverflowModeTrailingEllipsis, GTextAlignmentLeft, NULL);
 }
 
 static void filter(int button)
@@ -358,7 +358,7 @@ static void window_load(Window* me)
 {
 	Layer* topLayer = window_get_root_layer(window);
 
-	contactsMenuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, 144, 168 - 16));
+	contactsMenuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, SCREEN_WIDTH, HEIGHT_BELOW_STATUSBAR));
 
 	// Set all the callbacks for the menu layer
 	menu_layer_set_callbacks(contactsMenuLayer, NULL, (MenuLayerCallbacks){

--- a/src/MainMenuWindow.c
+++ b/src/MainMenuWindow.c
@@ -207,24 +207,24 @@ static void window_load(Window *me) {
 
 	Layer* topLayer = window_get_root_layer(me);
 
-	loadingLayer = text_layer_create(GRect(0, STATUSBAR_Y_OFFSET, 144, 168 - 16));
+	loadingLayer = text_layer_create(GRect(0, STATUSBAR_Y_OFFSET, SCREEN_WIDTH, HEIGHT_BELOW_STATUSBAR));
 	text_layer_set_text_alignment(loadingLayer, GTextAlignmentCenter);
 	text_layer_set_text(loadingLayer, "Loading...");
 	text_layer_set_font(loadingLayer, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
 	layer_add_child(topLayer, (Layer*) loadingLayer);
 
-	quitTitle = text_layer_create(GRect(0, 70 + STATUSBAR_Y_OFFSET, 144, 50));
+	quitTitle = text_layer_create(GRect(0, 70 + STATUSBAR_Y_OFFSET, SCREEN_WIDTH, 50));
 	text_layer_set_text_alignment(quitTitle, GTextAlignmentCenter);
 	text_layer_set_text(quitTitle, "Press back again if app does not close in several seconds");
 	layer_add_child(topLayer, (Layer*) quitTitle);
 
-	quitText = text_layer_create(GRect(0, 10 + STATUSBAR_Y_OFFSET, 144, 50));
+	quitText = text_layer_create(GRect(0, 10 + STATUSBAR_Y_OFFSET, SCREEN_WIDTH, 50));
 	text_layer_set_text_alignment(quitText, GTextAlignmentCenter);
 	text_layer_set_text(quitText, "Quitting...\n Please wait");
 	text_layer_set_font(quitText, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
 	layer_add_child(topLayer, (Layer*) quitText);
 
-	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, 144, 168 - 16));
+	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, SCREEN_WIDTH, HEIGHT_BELOW_STATUSBAR));
 
 	// Set all the callbacks for the menu layer
 	menu_layer_set_callbacks(menuLayer, NULL, (MenuLayerCallbacks){

--- a/src/NumberPickerWindow.c
+++ b/src/NumberPickerWindow.c
@@ -290,7 +290,14 @@ static void menu_pos_changed(struct MenuLayer *menu_layer, MenuIndex new_index, 
 static void menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuIndex *cell_index, void *data) {
 	GBitmap* icon = getNumberAction(cell_index->row) == 0 ? callIcon : messageIcon;
 
+#ifdef PBL_ROUND
+	char title[32];
+	strncpy(title, icon == callIcon ? "[Call] " : "[Msg] ", sizeof title - 1);
+	strncat(title, getNumberType(cell_index->row), sizeof title - 1 - strlen(title));
+	menu_cell_basic_draw(ctx, cell_layer, title, getNumber(cell_index->row), icon);
+#else
 	menu_cell_basic_draw(ctx, cell_layer, getNumberType(cell_index->row), getNumber(cell_index->row), icon);
+#endif
 }
 
 

--- a/src/NumberPickerWindow.c
+++ b/src/NumberPickerWindow.c
@@ -346,7 +346,7 @@ static void config_provider(void* context) {
 static void window_load(Window* me) {
 	Layer* topLayer = window_get_root_layer(window);
 
-	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, 144, 168 - 16));
+	menuLayer = menu_layer_create(GRect(0, STATUSBAR_Y_OFFSET, SCREEN_WIDTH, HEIGHT_BELOW_STATUSBAR));
 
 	// Set all the callbacks for the menu layer
 	menu_layer_set_callbacks(menuLayer, NULL, (MenuLayerCallbacks){

--- a/src/PebbleDialer.h
+++ b/src/PebbleDialer.h
@@ -8,11 +8,22 @@
 #ifndef PEBBLEDIALER_H_
 #define PEBBLEDIALER_H_
 
+
 #ifdef PBL_SDK_3
+	#define SCREEN_WIDTH  (PBL_IF_RECT_ELSE(144, 180))
+	#define SCREEN_HEIGHT (PBL_IF_RECT_ELSE(168, 180))
+
 	#define STATUSBAR_Y_OFFSET STATUS_BAR_LAYER_HEIGHT
+	#define HEIGHT_BELOW_STATUSBAR (SCREEN_HEIGHT - STATUSBAR_Y_OFFSET)
 	#define ACTIONBAR_X_OFFSET 0
 #else
+	#define PBL_IF_RECT_ELSE(if_true, if_false) (if_true)
+	#define PBL_IF_ROUND_ELSE(if_true, if_false) (if_false)
+	#define SCREEN_WIDTH  144
+	#define SCREEN_HEIGHT 168
+
 	#define STATUSBAR_Y_OFFSET 0
+	#define HEIGHT_BELOW_STATUSBAR (SCREEN_HEIGHT - 16)
 	#define ACTIONBAR_X_OFFSET 10
 #endif
 


### PR DESCRIPTION
I tried to adapt everything except for `tertiary_text.c`, and tested it on my unit.

The changes are mostly about screen size and position of objects. I also centered items in contact lists, because all other menus are centered on the Round interface. Also menus don't show icons on Round, so I added some text prefix to the number picker, in order to distinguish between call and message.

The position of the call info can be discussed, I felt that centering it left an ugly empty space on the left hand side, while pushing it to the left border was unbalanced the other way around. I choose a middle ground, slightly off-center, that I found the most aesthetically pleasing, but I could understand my view to be a minority.

Lastly, the action menu that pops out of tertiary_text was too high. Since that involves `tertiary_text.c` (I think), I left it out, but that's something to keep in mind.

Oh and I assumed you would do the merge of the updated `tertiary_text`, but if I'm wrong about that I don't mind doing it, just tell me.